### PR TITLE
[feat]: Added persistant observation saving to supabase

### DIFF
--- a/src/app/home/control-panel/control-panel.ts
+++ b/src/app/home/control-panel/control-panel.ts
@@ -48,7 +48,7 @@ export class ControlPanel {
   // running = false;
 
   async run() {
-    const observation: observationSubmissionDTO = 
+    const observation: observationFormDTO | {status: string} = 
       {...this.form.getRawValue() as unknown as observationFormDTO, status: "Pending"};
 
     const user = this.auth.user();
@@ -76,23 +76,54 @@ export class ControlPanel {
         "user_id": user?.id || ""
       },
     }
-    this.ObservationsService.addSubmission(observation);
+    this.ObservationsService.addSubmission(
+      {...reqBody.observation, 
+        ...reqBody.requestor, 
+        "status": "Pending", "message": ""
+      }
+    );
+
+    const {data, error} = await this.auth.supabase.from('observations')
+    .insert([{...reqBody.observation, ...reqBody.requestor}]) //remember to create corresponding_table
+    .select() //return uuid
+    if(error){
+      console.error(error)
+    }
+    const id = (data as any)[0].id
 
     try{
-      const res = await fetch(import.meta.env['NG_APP_API_URL'], { /* ... */ })
+      const res = await fetch(import.meta.env['NG_APP_API_URL'], {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(reqBody),
+      });
       
       if(!res.ok){
         // 2. Update status on failure
-        this.ObservationsService.updateSubmissionStatus(observation, "Failed");
+        this.ObservationsService.updateSubmissionStatus({...reqBody.observation, ...reqBody.requestor, status: "Pending", message: ""}, "Failed");
+        await this.auth.supabase
+        .from('observations')
+        .update({status: "Failed", message: `${res.status}`})
+        .eq('id', id)
         throw new Error(`Response Status: ${res.status}`)
       } else {
         // 2. Update status on success (if needed, or maybe the backend returns final status)
         // If the backend returns 'Finished', update it here
-         this.ObservationsService.updateSubmissionStatus(observation, "Finished"); 
+         this.ObservationsService.updateSubmissionStatus({...reqBody.observation, ...reqBody.requestor, status: "Pending", message: ""}, "Finished"); 
+         await this.auth.supabase
+        .from('observations')
+        .update({status: "Finished"})
+        .eq('id', id)
          // Or keep as pending if waiting for something else
       }
     } catch(e){
-       this.ObservationsService.updateSubmissionStatus(observation, "Failed");
+       this.ObservationsService.updateSubmissionStatus({...reqBody.observation, ...reqBody.requestor, status: "Pending", message: ""}, "Failed");
+       await this.auth.supabase
+        .from('observations')
+        .update({status: "Failed"})
+        .eq('id', id)
        console.error(e)
     }
   }

--- a/src/app/home/control-panel/dtos/control-panel.dto.ts
+++ b/src/app/home/control-panel/dtos/control-panel.dto.ts
@@ -22,6 +22,28 @@ export interface observationBodyDTO {
   }
 }
 
+export interface observationSubmissionDTO {
+    "observation_name": string,
+    "center_frequency": number,
+    "rf_gain": number, //optional later
+    "if_gain": number, //optional later
+    "bb_gain": number, //optional later
+    "dec": number, //optional later
+    "ra": number, //optional later
+    "bins": number,
+    "channels": number,
+    "bandwidth": string,
+    "integration_time": number,
+    "observation_type": string,
+    "output_filename": string,
+    "receive_csv": boolean,
+    "email": string,
+    "user_id": string,
+    "username": string,
+    "status": string,
+    "message": string
+}
+
 export interface observationFormDTO{
       name: String,
       observationType: String,
@@ -38,6 +60,3 @@ export interface observationFormDTO{
       csvBool: Boolean | String,
 }
 
-export interface observationSubmissionDTO extends observationFormDTO{
-      status: "Finished" | "Pending" | "Rejected" |"Failed"
-}

--- a/src/app/home/observation-history/observation-history.html
+++ b/src/app/home/observation-history/observation-history.html
@@ -8,7 +8,7 @@
             <div class="content">
 
                 @for(pastSubmission of observationSubmissions(); track pastSubmission){
-                    <div>{{pastSubmission.name}}'s status: {{pastSubmission.status}}</div>
+                    <div>{{pastSubmission.observation_name}}'s status: {{pastSubmission.status}}</div>
                 }
             <!-- 
                 ADD FUNCTIONALITY TO GET STATUS FROM EACH OBSERVATION FROM BACKEND 
@@ -31,22 +31,22 @@
                         <mat-expansion-panel>
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
-                                    {{pastSubmission["name"]}}
+                                    {{pastSubmission["observation_name"]}}
                                 </mat-panel-title>
                             </mat-expansion-panel-header>
                             <div>
-                                <div><strong>Center Frequency:</strong> {{pastSubmission.cFreq}}</div>
+                                <div><strong>Center Frequency:</strong> {{pastSubmission.center_frequency}}</div>
                                 <div><strong>Bandwidth:</strong> {{pastSubmission.bandwidth}}</div>
                                 <div><strong>Channels:</strong> {{pastSubmission.channels}}</div>
                                 <div><strong>Bins:</strong> {{pastSubmission.bins}}</div>
-                                <div><strong>RF Gain:</strong> {{pastSubmission.rfGain}}</div>
-                                <div><strong>IF Gain:</strong> {{pastSubmission.ifGain}}</div>
-                                <div><strong>Observation Type:</strong> {{pastSubmission.observationType}}</div>
+                                <div><strong>RF Gain:</strong> {{pastSubmission.rf_gain}}</div>
+                                <div><strong>IF Gain:</strong> {{pastSubmission.if_gain}}</div>
+                                <div><strong>Observation Type:</strong> {{pastSubmission.observation_type}}</div>
                                 <div><strong>RA:</strong> {{pastSubmission.ra}}</div>
                                 <div><strong>DEC:</strong> {{pastSubmission.dec}}</div>
-                                <div><strong>BB Gain:</strong> {{pastSubmission.bbGain}}</div>
-                                <div><strong>Duration:</strong> {{pastSubmission.duration}}s</div>
-                                <div><strong>CSV Output:</strong> {{pastSubmission.csvBool}}</div>
+                                <div><strong>BB Gain:</strong> {{pastSubmission.bb_gain}}</div>
+                                <div><strong>Duration:</strong> {{pastSubmission.integration_time}}s</div>
+                                <div><strong>CSV Output:</strong> {{pastSubmission.receive_csv}}</div>
                             </div>
                         </mat-expansion-panel>
                     }

--- a/src/app/home/observation-history/observation-history.ts
+++ b/src/app/home/observation-history/observation-history.ts
@@ -26,52 +26,6 @@ export class ObservationHistory {
   private authSubscription: any;
 
   constructor(){
-    // A) On page load, check for existing session
-    const user = this.auth.user();
-    if (user) {
-      this.handleState();
-    }
   }
 
-  ngOnInit() {
-    // B) Listen for new logins
-    this.authSubscription = this.auth.supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_IN') {
-        this.handleState();
-      }
-      if (event === 'SIGNED_OUT') {
-        this.deleteState();
-      }
-    }).data.subscription;
-  }
-
-  ngOnDestroy(){
-    if (this.authSubscription) {
-      this.authSubscription.unsubscribe();
-    }
-    this.deleteState()
-  }
-
-  // Directly reference the service signal
-  async handleState(){
-    const email = this.auth.user()?.email
-    const {data, error} = await this.auth.supabase
-    .from('observations')
-    .select('*')
-    .eq('email', email)
-
-    if (error) {
-      console.error(error);
-    } else {
-      // data contains all observations for this user
-      data.forEach(obs => {
-        this.obsService.addSubmission(obs)
-      });
-    }
-  }
-
-  async deleteState(){
-    this.obsService.deleteHistoryInstance()
-  }
-  
 }

--- a/src/app/home/observation-history/observation-history.ts
+++ b/src/app/home/observation-history/observation-history.ts
@@ -1,10 +1,12 @@
-import { Component, effect, signal, inject } from '@angular/core';
+import { Component, effect, signal, inject, OnInit, OnDestroy } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { observationSubmissionSignal } from '../../../services/signal';
 import { observationFormDTO , observationSubmissionDTO } from '../control-panel/dtos/control-panel.dto';
 import { ObservationsService } from '../../../services/observations';
+import { AuthService } from '../../../services/auth';
+import { Subscription, SubscriptionLike } from 'rxjs';
 
 @Component({
   selector: 'app-observation-history',
@@ -19,7 +21,57 @@ import { ObservationsService } from '../../../services/observations';
 
 export class ObservationHistory {
   private obsService = inject(ObservationsService);
-  
-  // Directly reference the service signal
   observationSubmissions = this.obsService.history;
+  private auth = inject(AuthService)
+  private authSubscription: any;
+
+  constructor(){
+    // A) On page load, check for existing session
+    const user = this.auth.user();
+    if (user) {
+      this.handleState();
+    }
+  }
+
+  ngOnInit() {
+    // B) Listen for new logins
+    this.authSubscription = this.auth.supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN') {
+        this.handleState();
+      }
+      if (event === 'SIGNED_OUT') {
+        this.deleteState();
+      }
+    }).data.subscription;
+  }
+
+  ngOnDestroy(){
+    if (this.authSubscription) {
+      this.authSubscription.unsubscribe();
+    }
+    this.deleteState()
+  }
+
+  // Directly reference the service signal
+  async handleState(){
+    const email = this.auth.user()?.email
+    const {data, error} = await this.auth.supabase
+    .from('observations')
+    .select('*')
+    .eq('email', email)
+
+    if (error) {
+      console.error(error);
+    } else {
+      // data contains all observations for this user
+      data.forEach(obs => {
+        this.obsService.addSubmission(obs)
+      });
+    }
+  }
+
+  async deleteState(){
+    this.obsService.deleteHistoryInstance()
+  }
+  
 }

--- a/src/services/observations.ts
+++ b/src/services/observations.ts
@@ -1,14 +1,33 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Validators } from '@angular/forms';
 import { signal } from '@angular/core';
 import { observationFormDTO, observationSubmissionDTO } from '../app/home/control-panel/dtos/control-panel.dto';
-
+import { AuthService } from './auth';
+import { inject } from '@angular/core/primitives/di';
 
 @Injectable({
   providedIn: 'root',
 })
 
 export class ObservationsService {
+  private auth = inject(AuthService)
+
+  constructor(){
+    this.auth.supabase.auth.onAuthStateChange((event, session)=>{
+      if (event === 'SIGNED_IN') {
+      this.handleState();
+    }
+    if (event === 'SIGNED_OUT') {
+      this.deleteHistoryInstance();
+    }
+    })
+
+    // Only fetch if user is present and no data loaded yet
+    const user = this.auth.user();
+    if (user) {
+      this.handleState();
+    }
+  }
 
   observation_fields = [
     {
@@ -149,6 +168,23 @@ export class ObservationsService {
 
   deleteHistoryInstance(){
     this.history.update(()=>{return []})
+  }
+
+  async handleState(){
+    const email = this.auth.user()?.email
+    const {data, error} = await this.auth.supabase
+    .from('observations')
+    .select('*')
+    .eq('email', email)
+
+    if (error) {
+      console.error(error);
+    } else {
+      // data contains all observations for this user
+      data.forEach(obs => {
+        this.addSubmission(obs)
+      });
+    }
   }
   
 }

--- a/src/services/observations.ts
+++ b/src/services/observations.ts
@@ -11,20 +11,25 @@ import { inject } from '@angular/core/primitives/di';
 
 export class ObservationsService {
   private auth = inject(AuthService)
+  private loaded = false;
 
   constructor(){
     this.auth.supabase.auth.onAuthStateChange((event, session)=>{
       if (event === 'SIGNED_IN') {
-      this.handleState();
-    }
-    if (event === 'SIGNED_OUT') {
-      this.deleteHistoryInstance();
-    }
+        if(!this.loaded){
+          this.handleState();
+        }
+        this.loaded = true;
+      }
+      if (event === 'SIGNED_OUT') {
+        this.deleteHistoryInstance();
+        this.loaded = false;
+      }
     })
 
     // Only fetch if user is present and no data loaded yet
     const user = this.auth.user();
-    if (user) {
+    if (user && !this.loaded && (!this.history() || this.history().length === 0)) {
       this.handleState();
     }
   }
@@ -181,6 +186,7 @@ export class ObservationsService {
       console.error(error);
     } else {
       // data contains all observations for this user
+      this.loaded = true;
       data.forEach(obs => {
         this.addSubmission(obs)
       });

--- a/src/services/observations.ts
+++ b/src/services/observations.ts
@@ -123,20 +123,32 @@ export class ObservationsService {
 
   ];
 
-  readonly history = signal<observationSubmissionDTO[]>([]);
+  readonly history = signal<observationSubmissionDTO[] | []>([]);
 
   // ...existing code... (keep your existing fields config)
 
   addSubmission(submission: observationSubmissionDTO) {
     // Add to top of list
-    this.history.update(list => [submission, ...list]);
+    this.history.update(list => [submission, ...(list as observationSubmissionDTO[])]);
   }
 
   updateSubmissionStatus(submission: observationSubmissionDTO, status: "Finished"| "Pending" | "Rejected" | "Failed") {
     // Update specific item completely immutably
-    this.history.update(list => 
-      list.map(item => item === submission ? { ...item, status } : item)
+    this.history.update(hist => 
+      (hist as observationSubmissionDTO[]).map(obs => {
+        // Remove status and message from both objects for comparison
+        const { status: obsStatus, message: obsMessage, ...obsRest } = obs;
+        const { status: subStatus, message: subMessage, ...subRest } = submission;
+        if(JSON.stringify(obsRest) === JSON.stringify(subRest)){
+          obs.status = status
+        }
+        return obs }
+      )
     );
+  }
+
+  deleteHistoryInstance(){
+    this.history.update(()=>{return []})
   }
   
 }


### PR DESCRIPTION
## 🧩 Summary

Added feature to store observations attempted to send to server from frontend to supabase

## ✅ Changes
- [X ] Feature / enhancement
- 
## 🔬 Details

Created observations table in supabase, changed submissiondto to match it, then inserted every added submission to it, and upon page load, either via current session or via loggin in with new user, fetching assignments belonging to user

## 🧪 Testing

Local Testing